### PR TITLE
feat: update PR status labels and action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: "Asana + Github - custom action (by Zignaly)"
+name: "Asana + Github - custom action (by De Monsterts)"
 description: "change status of target task when PR is reviewed or merged"
-author: "Pedro Moreno"
+author: "Steijn van der Laan"
 
 inputs:
   asana-token:

--- a/dist/index.js
+++ b/dist/index.js
@@ -127,8 +127,8 @@ async function run() {
     // Format 2: https://app.asana.com/0/<project>/<task>/f
     const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/f.*/gi;
     const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
-    const CODE_REVIEW = "CODE REVIEW";
-    const READY_FOR_QA = "READY FOR QA";
+    const CODE_REVIEW = "Merge Request Created";
+    const READY_FOR_QA = "Merged on Main";
     const prInfo = github.context.payload;
     if (!prInfo.pull_request) {
         core.setFailed("No pull request found.");

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ export async function run() {
 
   const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
 
-  const CODE_REVIEW = "CODE REVIEW";
-  const READY_FOR_QA = "READY FOR QA";
+  const CODE_REVIEW = "Merge Request Created";
+  const READY_FOR_QA = "Merged on Main";
 
   const prInfo = github.context.payload;
   if (!prInfo.pull_request) {


### PR DESCRIPTION
Change PR status constants from "CODE REVIEW" and "READY FOR QA" to
"Merge Request Created" and "Merged on Main" to better reflect the
current workflow terminology. Update action metadata author and name
to reflect new ownership and maintain accurate attribution.