### PR TITLE
fix: ensure status checks use uppercase constants

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -179,10 +179,10 @@ async function run() {
     const filteredOptions = filterDevStatusId[0].enum_options
         .map((o) => {
         let name = o.name.toUpperCase();
-        if (name.includes(READY_FOR_QA)) {
+        if (name.includes(READY_FOR_QA.toUpperCase())) {
             name = READY_FOR_QA;
         }
-        if (name.includes(CODE_REVIEW)) {
+        if (name.includes(CODE_REVIEW.toUpperCase())) {
             name = CODE_REVIEW;
         }
         return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,10 +75,10 @@ export async function run() {
   const filteredOptions = filterDevStatusId[0].enum_options
     .map((o) => {
       let name = o.name.toUpperCase();
-      if (name.includes(READY_FOR_QA)) {
+      if (name.includes(READY_FOR_QA.toUpperCase())) {
         name = READY_FOR_QA;
       }
-      if (name.includes(CODE_REVIEW)) {
+      if (name.includes(CODE_REVIEW.toUpperCase())) {
         name = CODE_REVIEW;
       }
       return {


### PR DESCRIPTION
Convert READY_FOR_QA and CODE_REVIEW constants to uppercase before
checking inclusion in status names. This prevents case mismatch issues
and ensures consistent filtering of development status options.