### PR TITLE
fix: normalize status names to uppercase consistently

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -180,10 +180,10 @@ async function run() {
         .map((o) => {
         let name = o.name.toUpperCase();
         if (name.includes(READY_FOR_QA.toUpperCase())) {
-            name = READY_FOR_QA;
+            name = READY_FOR_QA.toUpperCase();
         }
         if (name.includes(CODE_REVIEW.toUpperCase())) {
-            name = CODE_REVIEW;
+            name = CODE_REVIEW.toUpperCase();
         }
         return {
             name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-ci-asana",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,10 +76,10 @@ export async function run() {
     .map((o) => {
       let name = o.name.toUpperCase();
       if (name.includes(READY_FOR_QA.toUpperCase())) {
-        name = READY_FOR_QA;
+        name = READY_FOR_QA.toUpperCase();
       }
       if (name.includes(CODE_REVIEW.toUpperCase())) {
-        name = CODE_REVIEW;
+        name = CODE_REVIEW.toUpperCase();
       }
       return {
         name,


### PR DESCRIPTION
Convert READY_FOR_QA and CODE_REVIEW status names to uppercase
when assigning them, ensuring consistent formatting across the
codebase. This change prevents potential mismatches caused by
case differences during status checks and improves reliability.  
Also bump the package version to 1.0.2 to reflect these updates.