### PR TITLE
chore: bump version to 1.0.4 and clean up debug logs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -122,6 +122,7 @@ const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const asana_1 = __importDefault(__nccwpck_require__(4050));
 async function run() {
+    var _a;
     // Format 1: https://app.asana.com/1/1200203178379976/project/<project>/task/<taskId>
     const ASANA_TASK_LINK_REGEX_FORMAT1 = /https:\/\/app\.asana\.com\/\d+\/\d+\/project\/(?<project>\d+)\/task\/(?<taskId>\d+).*/gi;
     // Format 2: https://app.asana.com/0/<project>/<task>/f
@@ -191,9 +192,6 @@ async function run() {
         };
     })
         .filter((o) => optionsList.includes(o.name.toUpperCase()));
-    console.log("filterDevStatusId[0].enum_options", filterDevStatusId[0].enum_options);
-    console.log("optionsList", optionsList);
-    console.log("filteredOptions", filteredOptions);
     if (optionsList.length !== filteredOptions.length) {
         core.setFailed(`Not all options are available in the field. One or more options is missing: ${optionsList}`);
         return;
@@ -203,6 +201,7 @@ async function run() {
         return acc;
     }, {});
     const eventName = github.context.eventName;
+    const merged = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.merged;
     const action = prInfo.action;
     const prAuthor = prInfo.pull_request.user.login;
     const status = (() => {
@@ -214,6 +213,9 @@ async function run() {
                 return option[CODE_REVIEW];
             }
             else if (eventName === "pull_request_review" && prInfo.review.state === "approved") {
+                return option[READY_FOR_QA];
+            }
+            else if (eventName === "pull_request" && action === "closed" && merged) {
                 return option[READY_FOR_QA];
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-ci-asana",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,10 +88,6 @@ export async function run() {
     })
     .filter((o) => optionsList.includes(o.name.toUpperCase()));
 
-  console.log("filterDevStatusId[0].enum_options", filterDevStatusId[0].enum_options);
-  console.log("optionsList", optionsList);
-  console.log("filteredOptions", filteredOptions);
-
   if (optionsList.length !== filteredOptions.length) {
     core.setFailed(`Not all options are available in the field. One or more options is missing: ${optionsList}`);
     return;
@@ -103,6 +99,7 @@ export async function run() {
   }, {});
 
   const eventName = github.context.eventName;
+  const merged = github.context.payload.pull_request?.merged;
   const action = prInfo.action;
 
   const prAuthor = prInfo.pull_request.user.login;
@@ -114,6 +111,8 @@ export async function run() {
       if (eventName === "pull_request" && (action === "opened" || action === "reopened")) {
         return option[CODE_REVIEW];
       } else if (eventName === "pull_request_review" && prInfo.review.state === "approved") {
+        return option[READY_FOR_QA];
+      } else if (eventName === "pull_request" && action === "closed" && merged) {
         return option[READY_FOR_QA];
       }
     }


### PR DESCRIPTION
Remove console.log debug statements from main.ts to reduce noise
in the output. Add handling for merged pull requests to set the
status to READY_FOR_QA when a PR is closed and merged. This ensures
correct status updates in the workflow based on PR merge events.