### PR TITLE
fix(regex): allow optional trailing slash and 'f' in Asana links

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -126,7 +126,7 @@ async function run() {
     // Format 1: https://app.asana.com/1/1200203178379976/project/<project>/task/<taskId>
     const ASANA_TASK_LINK_REGEX_FORMAT1 = /https:\/\/app\.asana\.com\/\d+\/\d+\/project\/(?<project>\d+)\/task\/(?<taskId>\d+).*/gi;
     // Format 2: https://app.asana.com/0/<project>/<task>/f
-    const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/f.*/gi;
+    const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
     const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
     const CODE_REVIEW = "Merge Request Created".toUpperCase();
     const READY_FOR_QA = "Merged on Main".toUpperCase();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-ci-asana",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ export async function run() {
     /https:\/\/app\.asana\.com\/\d+\/\d+\/project\/(?<project>\d+)\/task\/(?<taskId>\d+).*/gi;
 
   // Format 2: https://app.asana.com/0/<project>/<task>/f
-  const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/f.*/gi;
+  const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
 
   const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
 


### PR DESCRIPTION
Update ASANA_TASK_LINK_REGEX_FORMAT2 to match URLs with or without
a trailing slash and optional 'f' character. This improves link
matching flexibility for Asana task URLs in different formats.