### PR TITLE
fix: change failure to notice when no task id found

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -162,7 +162,7 @@ async function run() {
         }
     }
     if (taskIds.length === 0) {
-        core.setFailed("No task id found in the description. Or link is missing.");
+        core.notice("No task id found in the description. Or link is missing.");
         return;
     }
     const task = await asana_1.default.getTask(taskIds[0]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-ci-asana",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ export async function run() {
   }
 
   if (taskIds.length === 0) {
-    core.setFailed("No task id found in the description. Or link is missing.");
+    core.notice("No task id found in the description. Or link is missing.");
     return;
   }
 


### PR DESCRIPTION
core.setFailed with core.notice when task id is found in the
 or the link is. This prevents the from being
marked as failed for missing task identifiers and allows workflows to
continue while still surface a non-blocking notification to the user.

Use a notice instead of a hard failure to improve resilience of the
workflow and avoid false negatives caused by optional task links.