### PR TITLE
fix: avoid failing when PR is missing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -137,7 +137,7 @@ async function run() {
     }
     const description = prInfo.pull_request.body;
     if (!description) {
-        core.setFailed("No description found for this pull request.");
+        core.notice("No description found for this pull request.");
         return;
     }
     const taskIds = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-ci-asana",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ export async function run() {
 
   const description = prInfo.pull_request.body;
   if (!description) {
-    core.setFailed("No description found for this pull request.");
+    core.notice("No description found for this pull request.");
     return;
   }
 


### PR DESCRIPTION
Change behavior when a pull has no description
from failing the action to issuing a notice instead. This
prevents the workflow from being marked as failed for the
absence of a PR body and allows subsequent steps to continue.

Also bump package version to 1.0.7 to reflect the release
containing this fix. Updated both source (src/main.ts) and
built output (dist/index.js) to replace core.setFailed with
core.notice.