### PR TITLE
feat(asana): extract task IDs from /home/ task URLs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -127,6 +127,7 @@ async function run() {
     const ASANA_TASK_LINK_REGEX_FORMAT1 = /https:\/\/app\.asana\.com\/\d+\/\d+\/project\/(?<project>\d+)\/task\/(?<taskId>\d+).*/gi;
     // Format 2: https://app.asana.com/0/<project>/<task>/f
     const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
+    const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<taskId>\d+)\/?f?.*/gi;
     const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
     const CODE_REVIEW = "Merge Request Created".toUpperCase();
     const READY_FOR_QA = "Merged on Main".toUpperCase();
@@ -159,6 +160,16 @@ async function run() {
         }
         if (match2.groups && match2.groups.taskId) {
             taskIds.push(match2.groups.taskId);
+        }
+    }
+    // Extract task IDs from Format 3 URLs
+    let match3;
+    while ((match3 = ASANA_TASK_LINK_REGEX_FORMAT3.exec(description)) !== null) {
+        if (match3.index === ASANA_TASK_LINK_REGEX_FORMAT3.lastIndex) {
+            ASANA_TASK_LINK_REGEX_FORMAT3.lastIndex++;
+        }
+        if (match3.groups && match3.groups.taskId) {
+            taskIds.push(match3.groups.taskId);
         }
     }
     if (taskIds.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-ci-asana",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ export async function run() {
   // Format 2: https://app.asana.com/0/<project>/<task>/f
   const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
 
+  const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<taskId>\d+)\/?f?.*/gi;
+
   const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
 
   const CODE_REVIEW = "Merge Request Created".toUpperCase();
@@ -48,6 +50,17 @@ export async function run() {
     }
     if (match2.groups && match2.groups.taskId) {
       taskIds.push(match2.groups.taskId);
+    }
+  }
+
+  // Extract task IDs from Format 3 URLs
+  let match3;
+  while ((match3 = ASANA_TASK_LINK_REGEX_FORMAT3.exec(description)) !== null) {
+    if (match3.index === ASANA_TASK_LINK_REGEX_FORMAT3.lastIndex) {
+      ASANA_TASK_LINK_REGEX_FORMAT3.lastIndex++;
+    }
+    if (match3.groups && match3.groups.taskId) {
+      taskIds.push(match3.groups.taskId);
     }
   }
 


### PR DESCRIPTION
Add support for a third Asana URL format (https://app.asana.com/0/home/<taskId>/)
by introducing ASANA_TASK_LINK_REGEX_FORMAT3 and scanning descriptions with
. Update both source (src/main) and built output (dist/index.js) to parse
and push task IDs found in the new URL form.

This enables the action to recognize task links copied from the Asana "Home"
view and include those task IDs in downstream processing (e.g., labeling or
status updates).