### PR TITLE
(asana): project id in home regex

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -127,7 +127,7 @@ async function run() {
     const ASANA_TASK_LINK_REGEX_FORMAT1 = /https:\/\/app\.asana\.com\/\d+\/\d+\/project\/(?<project>\d+)\/task\/(?<taskId>\d+).*/gi;
     // Format 2: https://app.asana.com/0/<project>/<task>/f
     const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
-    const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<taskId>\d+)\/?f?.*/gi;
+    const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
     const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
     const CODE_REVIEW = "Merge Request Created".toUpperCase();
     const READY_FOR_QA = "Merged on Main".toUpperCase();

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export async function run() {
   // Format 2: https://app.asana.com/0/<project>/<task>/f
   const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
 
-  const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<taskId>\d+)\/?f?.*/gi;
+  const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
 
   const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
 


### PR DESCRIPTION
Update Asana "home" link regular expression to capture both project
and task id. Previously the regex only captured the task id for URLs
like /0/home/<taskId>, which caused incorrect parsing for links that
include the project segment (e.g. /0/home/<project>/<taskId>). Adding
the project capture group ensures consistent extraction of project and
task IDs across all Asana URL formats and prevents downstream errors
when mapping links to tasks. Adjusted both src and built dist files.