### PR TITLE
feat(asana): parse task IDs from Asana search URLs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -128,6 +128,9 @@ async function run() {
     // Format 2: https://app.asana.com/0/<project>/<task>/f
     const ASANA_TASK_LINK_REGEX_FORMAT2 = /https:\/\/app\.asana\.com\/0\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
     const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
+    // Regex for parse url like: https://app.asana.com/0/search?q=groepen&searched_type=task&child=1210562993211967
+    // Regex for URLs like: https://app.asana.com/0/search?q=groepen&searched_type=task&child=1210562993211967
+    const ASANA_TASK_LINK_REGEX_FORMAT4 = /https:\/\/app\.asana\.com\/0\/search\?[^ ]*child=(?<taskId>\d+)/gi;
     const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
     const CODE_REVIEW = "Merge Request Created".toUpperCase();
     const READY_FOR_QA = "Merged on Main".toUpperCase();
@@ -170,6 +173,15 @@ async function run() {
         }
         if (match3.groups && match3.groups.taskId) {
             taskIds.push(match3.groups.taskId);
+        }
+    }
+    let match4;
+    while ((match4 = ASANA_TASK_LINK_REGEX_FORMAT4.exec(description)) !== null) {
+        if (match4.index === ASANA_TASK_LINK_REGEX_FORMAT4.lastIndex) {
+            ASANA_TASK_LINK_REGEX_FORMAT4.lastIndex++;
+        }
+        if (match4.groups && match4.groups.taskId) {
+            taskIds.push(match4.groups.taskId);
         }
     }
     if (taskIds.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga-ci-asana",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,10 @@ export async function run() {
 
   const ASANA_TASK_LINK_REGEX_FORMAT3 = /https:\/\/app\.asana\.com\/0\/home\/(?<project>\d+)\/(?<taskId>\d+)\/?f?.*/gi;
 
+  // Regex for parse url like: https://app.asana.com/0/search?q=groepen&searched_type=task&child=1210562993211967
+  // Regex for URLs like: https://app.asana.com/0/search?q=groepen&searched_type=task&child=1210562993211967
+  const ASANA_TASK_LINK_REGEX_FORMAT4 = /https:\/\/app\.asana\.com\/0\/search\?[^ ]*child=(?<taskId>\d+)/gi;
+
   const WHITELIST_GITHUB_USERS = (core.getInput("whitelist-github-users") || "").split(",");
 
   const CODE_REVIEW = "Merge Request Created".toUpperCase();
@@ -61,6 +65,16 @@ export async function run() {
     }
     if (match3.groups && match3.groups.taskId) {
       taskIds.push(match3.groups.taskId);
+    }
+  }
+
+  let match4;
+  while ((match4 = ASANA_TASK_LINK_REGEX_FORMAT4.exec(description)) !== null) {
+    if (match4.index === ASANA_TASK_LINK_REGEX_FORMAT4.lastIndex) {
+      ASANA_TASK_LINK_REGEX_FORMAT4.lastIndex++;
+    }
+    if (match4.groups && match4.groups.taskId) {
+      taskIds.push(match4.groups.taskId);
     }
   }
 


### PR DESCRIPTION
Add a new regex to recognize Asana search URLs containing a
child=<taskId> parameter and extract task IDs from those links.
Update parsing loop to iterate matches from the new pattern and
append found task IDs to the existing list. Bump package version
to 1.0.9 and update compiled dist file accordingly.

This enables the action to detect Asana tasks referenced via
search URLs (e.g. ?child=1210562993211967), improving task
detection coverage for various Asana link formats.